### PR TITLE
Correção de gramática e conceito de escopo.

### DIFF
--- a/source/_posts/2015-02-23-looping-com-funcao-anonima-auto-executavel.markdown
+++ b/source/_posts/2015-02-23-looping-com-funcao-anonima-auto-executavel.markdown
@@ -31,7 +31,7 @@ Ao executar esse trecho de código nos deparamos com o alert sempre com o valor 
 
 **Oh God, Help me!**
 
-Take easy boy, vamos entender o que acontece. 
+Take it easy boy, vamos entender o que acontece. 
 
 O `i` dentro closure aponta para `i` global.  Quando chamamos a função `func[0]()` o `i` será 3 por que o valor do `i` global é 3.
 
@@ -54,15 +54,21 @@ for( var i = 0; i < users.length; i+=1) {
 Isso acontece porque `i` é global dentro desse escopo, logo o valor dele é 3 e `users[i]` aparece como `undefined` pois a posição 3 não existe.
 
 
-A solução é simples, devemos isolar cada índice, criando um escopo com uma função anônima auto-executável para que o valor do `i` seja preservado em cada interação, veja o exemplo:
+A solução é simples, devemos isolar cada índice, criando um escopo com uma função anônima auto-executável para que o valor do `i` seja preservado em cada iteração, veja o exemplo:
 
 ``` javascript função anônima auto-executável com looping
 var func = [];
 for( var i = 0; i < 3; i++ ){
     func[i] = (function (index) {
-        alert(index)
+        return function() { 
+            alert(index); 
+        };
     })(i) // Índice do looping sendo passado como parâmetro
 }
+
+func[0](); // alert 0
+func[1](); // alert 1
+func[2](); //alert 2
 ```
 
 
@@ -72,20 +78,19 @@ Exemplo usando com ajax:
 ``` javascript função anônima auto-executável com looping
 var func = [];
 var users = [1028,885,931];
-for( var i = 0; i < users.length; i+=1)(function (index) {
-$.ajax({
-        url: 'http://echo.jsontest.com/users/'+ users[index] ,
+for( var i = 0; i < users.length; i+=1)
+    $.ajax({
+        url: 'http://echo.jsontest.com/users/'+ users[i] ,
         dataType: "json",
-        success: function( response ) {
-            console.log(users[index]) //undefined
-            console.log( response ); // resposta
-        }
+        success: (function(index) {
+            return function( response ) {
+                console.log(users[index]) //undefined
+                console.log( response ); // resposta
+            };
+        })(i)// Índice do looping sendo passado como parâmetro
     });
-})(i)// Índice do looping sendo passado como parâmetro
 ```
 O Javascript possui vários gotchas. [Jonathan Cardy](http://www.codeproject.com/Articles/182416/A-Collection-of-JavaScript-Gotchas) escreveu um post bem completo, sobre vários gotchas do Javascript, vale uma lida.
 
-Já com relação a closures, existe um post no [stackoverflow](http://stackoverflow.com/questions/111102/how-do-javascript-closures-work) detalhando sobre o assunto.
-
-
+Já com relação a closures, existe um post no [stackoverflow](http://stackoverflow.com/questions/111102/how-do-javascript-closures-work) detalhando sobre o assunto.  
 

--- a/source/_posts/2015-02-23-looping-com-funcao-anonima-auto-executavel.markdown
+++ b/source/_posts/2015-02-23-looping-com-funcao-anonima-auto-executavel.markdown
@@ -84,7 +84,7 @@ for( var i = 0; i < users.length; i+=1)
         dataType: "json",
         success: (function(index) {
             return function( response ) {
-                console.log(users[index]) //undefined
+                console.log(users[index]) // usuário correto
                 console.log( response ); // resposta
             };
         })(i)// Índice do looping sendo passado como parâmetro


### PR DESCRIPTION
Algumas correções gramaticais bem simples foram feitas, mas o mais importante aqui é o conceito de escopo que está tentando passar.

Pelo que entendi, sua explicação tenta resolver o problema de tentar acessar posteriormente (de forma síncrona ou assíncrona) o valor de uma variável iterada em um laço de repetição, certo?

No seguinte código : 

``` javascript
for ( var i = 0; i < 3; i++ ) {
    func[i] = (function(index) {
        alert(index);
    })(i);
}
```

Você não está guardando o valor da variável iterada no escopo da função criada para uso posterior. Você está executando a função com um ` alert`, que vai ser executado na ordem em que o laço de repetição for executado, o que não é diferente de simplesmente colocar um `alert(i)` no bloco do `for`. Além de retornar `undefined` para a variável `func[i]`, o que eu acho que não é o resultado esperado, certo?

Para que a variável iterada seja realmente guardada no escopo da função `func[i]`, o seguinte código deve ser utilizado : 

``` javascript
for ( var i = 0; i < 3; i++ ) {
    func[i] = (function(index) {
        return function() {
            alert(index);
        };
    })(i);
}
```

Dessa forma você pode chamar `func[0]()`, `func[1]()` e `func[2]()`, que seus respectivos valores serão apresentados no `alert`.

Seu exemplo do ajax funciona corretamente. Só sugeri essa modificação por não ser muito usual englobar toda a chamada do ajax na função anônima, mas sim apenas o `callback`.