### PR TITLE
Correções gramaticais e esclarecimento do conceito da variável that.

### DIFF
--- a/source/_posts/2015-02-26-membros-privados-em-javascript.markdown
+++ b/source/_posts/2015-02-26-membros-privados-em-javascript.markdown
@@ -1,4 +1,4 @@
----
+--
 layout: post
 title: "Membros Privados em Javascript"
 date: 2015-02-26 15:04:53 -0300
@@ -11,7 +11,7 @@ categories: [javascript, tips]
 
 Quem nunca se perguntou: _"Como faço para deixar minhas variáveis e métodos privados com Javascript?"_. Pois bem, tentarei de uma forma bem pragmática mostrar como fazemos isso.
 
-Algumas pessoas acreditam que o Javascript não tem a capacidade de _"esconder informações"_, porquê `object` não pode ter variáveis e métodos privados. Mas isso não passa de um mal-entendido.
+Algumas pessoas acreditam que o Javascript não tem a capacidade de _"esconder informações"_, porque `object` não pode ter variáveis e métodos privados. Mas isso não passa de um mal-entendido.
 
 #### _Sim! Objetos Javascript podem ter membros privados._
 
@@ -27,7 +27,7 @@ Objetos são coleções de pares nome-valor. Os nomes são _strings_ e o valores
 
 ## Membros Públicos
 
-Os membros de um `object` são, sem exceção públicos. Qualquer função pode acessar, modificar, deletar ou até mesmo adicionar novos membros. Existem duas maneiras principais de inserir membros em um novo objeto:
+Os membros de um `object` são, sem exceção, públicos. Qualquer função pode acessar, modificar, deletar ou até mesmo adicionar novos membros. Existem duas maneiras principais de inserir membros em um novo objeto:
 
 ### No construtor
 
@@ -49,7 +49,7 @@ O valor de `novo_objeto.membro` será `a-b-c`.
 
 ### No prototype
 
-Esta técnica é utilizada para adicionar _métodos_ públicos. Quando um mebro é procurado dentro do próprio objeto e não é encontrado, ele é retirado do protótipo do Construtor do objeto. O mecânismo do _prototype_ é usado para herança. O que também conserva a memória. Para adicionar um método para todos os objetos criados a partir do Construtor do prototype:
+Esta técnica é utilizada para adicionar _métodos_ públicos. Quando um membro é procurado dentro do próprio objeto e não é encontrado, ele é retirado do protótipo do Construtor do objeto. O mecânismo do _prototype_ é usado para herança. O que também conserva a memória. Para adicionar um método para todos os objetos criados a partir do protótipo do Construtor:
 
 ``` javascript
 Adicionar.prototype.stamp = function ( string ) {
@@ -127,16 +127,16 @@ function Container ( param ) {
 
 Então temos o método privilegiado `escreve` que acessa os valores definidos dentro do _Construtor_, porém não pode alterá-los. \o/
 
-Isso só é possível porquê existem as _Closures_ no Javascript.
+Isso só é possível porque existem as _Closures_ no Javascript.
 
 ## Closures
 
 Os padrões de membros `public`, `private` e `privileged` só se tornam possíveis pelo fato da linguagem Javascript possuir _Closures_.
 
-Isso quer dizer que uma função interna sempre tem acesso as variáveis e parâmetros da função externa, mesmo depois dela já ter executado.
+Isso quer dizer que uma função interna sempre tem acesso as variáveis e parâmetros da função externa, mesmo depois de ela já ter executado.
 Essa é uma propriedade muito poderosa da linguagem Javascript!
 
-Métodos privados e privilegiados só podem ser atribuidos enquanto o objeto está sendo construído, já os públicos podem ser adicionados a qualquer momento.
+Métodos privados e privilegiados só podem ser atribuídos enquanto o objeto está sendo construído, já os públicos podem ser adicionados a qualquer momento.
 
 ## Padrões utilizando Closures
 

--- a/source/_posts/2015-02-26-membros-privados-em-javascript.markdown
+++ b/source/_posts/2015-02-26-membros-privados-em-javascript.markdown
@@ -49,7 +49,7 @@ O valor de `novo_objeto.membro` será `a-b-c`.
 
 ### No prototype
 
-Esta técnica é utilizada para adicionar _métodos_ públicos. Quando um membro é procurado dentro do próprio objeto e não é encontrado, ele é retirado do protótipo do Construtor do objeto. O mecânismo do _prototype_ é usado para herança. O que também conserva a memória. Para adicionar um método para todos os objetos criados a partir do protótipo do Construtor:
+Esta técnica é utilizada para adicionar _métodos_ públicos. Quando um membro é procurado dentro do próprio objeto e não é encontrado, ele é retirado do protótipo do Construtor do objeto. O mecânismo do _prototype_ é usado para herança. O que também conserva a memória. Para adicionar um método para todos os objetos criados a partir do Construtor, adicione uma função ao protótipo do Construtor:
 
 ``` javascript
 Adicionar.prototype.stamp = function ( string ) {

--- a/source/_posts/2015-02-26-membros-privados-em-javascript.markdown
+++ b/source/_posts/2015-02-26-membros-privados-em-javascript.markdown
@@ -1,4 +1,4 @@
---
+---
 layout: post
 title: "Membros Privados em Javascript"
 date: 2015-02-26 15:04:53 -0300
@@ -86,7 +86,7 @@ function Container ( param ) {
 		that    = this;
 	//
 	function resgata () {
-		if ( limite > 0 ) {
+		if ( limite > 0 && 'undefined' !== typeof that.membro) {
 			return true
 		} else {
 			return false
@@ -120,7 +120,7 @@ function Container ( param ) {
 	}
 	//
 	this.escreve = function () {
-		return resgata() ? that.membro : null;
+		return resgata() ? this.membro : null;
 	}
 }
 ```


### PR DESCRIPTION
A maioria das correções foram gramaticais/ortográficas. Só há uma sugestão em relação ao exemplo da variável `that`, que mesmo no exemplo criado pelo [Douglas Crockford](http://javascript.crockford.com/private.html), está um pouco estranha.

No seguinte trecho do post : 
> Por convenção, nós declaramos a variável `that` privada. Isso é usado para tornar o objeto disponível para os métodos privados, pois ao usar o `this` dentro da função ele apontará para o `this` dela mesma e não para o `this` do Construtor.

É apresentado o conceito de utilizar o `this` onde ele não é corretamente atribuído ao objeto instanciado (funções privadas e referências a métodos públicos, i.e : `$('seletor').on('click, objeto.metodo);`), mas no exemplo dado no post, o `that` é utilizado em um método público, onde o `this` é corretamente associado ao objeto. Ou seja, o `that` é desnecessário nesse caso:

```javascript
this.escreve = function () {
    return resgata() ? that.membro : null;
}
```

Pra quem está começando, acho um exemplo confuso, por isso modifiquei o código onde o `that` é utilizado desnecessariamente : 
```javascript
this.escreve = function () {
    return resgata() ? this.membro : null;
}
```

E adicionei o `that` onde ele realmente seria útil (método privado): 
```javascript
function resgata () {
    if ( limite > 0 && 'undefined' !== typeof that.membro) {
        return true
    } else {
        return false
    }
}
```
